### PR TITLE
Make library compatible with JDK 8

### DIFF
--- a/src/whitespace_linter.clj
+++ b/src/whitespace_linter.clj
@@ -6,7 +6,7 @@
             [methodical.core :as m]
             [progrock.core :as pr])
   (:import [java.io File LineNumberReader]
-           [java.nio.file Files FileVisitOption Path]
+           [java.nio.file Files FileSystems FileVisitOption Path]
            java.nio.file.attribute.BasicFileAttributes
            java.util.function.BiPredicate))
 
@@ -204,7 +204,7 @@
 
 (m/defmethod find-files-to-lint String
   [^String s options]
-  (find-files-to-lint (Path/of s (into-array String [])) options))
+  (find-files-to-lint (.getPath (FileSystems/getDefault) s (into-array String [])) options))
 
 (m/defmethod find-files-to-lint clojure.lang.Symbol
   [symb options]


### PR DESCRIPTION
Path/of was added in JDK 11.
For JDK 8 compatibility, go old school.

Ref: https://github.com/openjdk/jdk/blob/829dea45c9ab90518f03a66aad7e681cd4fda8b3/src/java.base/share/classes/java/nio/file/Path.java#L146-L148

Closes #5