### PR TITLE
Support only OS-agnostic file separator character

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Several options are currently supported:
 
 `:include-patterns` and `:exclude-patterns` accept either Strings or regex literals (regex literals cannot be embedded in EDN, so use string equivalents instead).
 
+Windows users: The backslash is not recognized as a file separator, use the forward slash `/` for the file separator character in paths and patterns.
+
 # Extensibility
 
 The code uses [Methodical](https://github.com/camsaul/methodical) under the hood for easy extensibility. It takes

--- a/src/whitespace_linter.clj
+++ b/src/whitespace_linter.clj
@@ -12,8 +12,6 @@
 
 (set! *warn-on-reflection* true)
 
-(def windows? (str/starts-with? (System/getProperty "os.name") "Windows"))
-
 (m/defmulti lint-char
   {:arglists '([ch options])}
   :none
@@ -167,8 +165,8 @@
     (type file-or-dir)))
 
 (defn unix-style-path [path]
-  (if windows?
-    (str/replace path "\\" "/")
+  (if (not= "/" File/separator)
+    (str/replace path File/separator "/")
     path))
 
 (defn lint-file? ^Boolean [^Path path {:keys [include-patterns exclude-patterns max-file-size-kb]}]

--- a/src/whitespace_linter.clj
+++ b/src/whitespace_linter.clj
@@ -12,6 +12,8 @@
 
 (set! *warn-on-reflection* true)
 
+(def windows? (str/starts-with? (System/getProperty "os.name") "Windows"))
+
 (m/defmulti lint-char
   {:arglists '([ch options])}
   :none
@@ -164,8 +166,13 @@
   (fn [file-or-dir _]
     (type file-or-dir)))
 
+(defn unix-style-path [path]
+  (if windows?
+    (str/replace path "\\" "/")
+    path))
+
 (defn lint-file? ^Boolean [^Path path {:keys [include-patterns exclude-patterns max-file-size-kb]}]
-  (let [path-str         (str path)
+  (let [path-str         (unix-style-path (str path))
         matches-pattern? (fn [pattern]
                            (re-find pattern path-str))]
     (boolean


### PR DESCRIPTION
Explicitly support only forward slash as a file separator
character on Windows for input paths and patterns.

This allows for cross-OS linting.

Closes #6