### PR TITLE
Add UNIX-style newline linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 {com.github.camsaul/whitespace-linter {:sha "81381ea6ddc2c27862cdb4df451e413a047d2411"}}
 ```
 
-Fast multithreaded and customizable linter that checks files for trailing whitespace, tabs, files that don't end in
+Fast multithreaded and customizable linter that checks files for trailing whitespace, tabs, carriage returns, files that don't end in
 newlines, files that end in blank lines, [Unicode characters that look maddeningly similar to ASCII
 ones](https://github.com/camsaul/emacs-unicode-troll-stopper), and invisible Unicode characters. Written in Clojure,
 but works on any sort of text file.

--- a/src/whitespace_linter.clj
+++ b/src/whitespace_linter.clj
@@ -157,6 +157,19 @@
           :line-number (.getLineNumber r)
           :line        last-line}]))))
 
+;; NOTE: at the moment we don't inform of the specific lines at fault,
+;; because LineNumberReader abstracts over \return characters,
+;; so we can't use LineNumberReader for detecting them.
+(m/defmethod lint-file :file/no-carriage-returns
+  [^File file options]
+  (with-open [r (io/reader file)]
+    (let [contents (slurp r)
+          matches (count (re-seq #"\r" contents))]
+      (when (pos? matches)
+        [{:linter  :file/no-carriage-returns
+          :message (format "Found %s carriage return characters. Please use Unix newlines instead!"
+                           matches)}]))))
+
 ;; TODO -- a linter that checks that the file uses UTF-8 encoding
 
 (m/defmulti find-files-to-lint


### PR DESCRIPTION
Fixes https://github.com/camsaul/whitespace-linter/issues/2

I verified it works as intended:

![image](https://user-images.githubusercontent.com/1162994/147385791-d4384a2a-ebe2-45f3-93ff-9deabe31d01f.png)
